### PR TITLE
bit-permutations: sync [bit.permute] synopsis comment with subclause title

### DIFF
--- a/src/bit-permutations.bs
+++ b/src/bit-permutations.bs
@@ -765,7 +765,7 @@ update the synopsis as follows:
 template&lt;class T&gt;
   constexpr int popcount(T x) noexcept;
 
-<ins>// [bit.permute], permutations
+<ins>// [bit.permute], permutation
 template&lt;class T&gt;
   constexpr T bit_reverse(T x) noexcept;
 template&lt;class T&gt;


### PR DESCRIPTION
## Summary

In \`src/bit-permutations.bs\` the \`<ins>\` block that introduces the new synopsis for [bit.permute] had:

\`\`\`cpp
// [bit.permute], permutations
\`\`\`

but the proposed subclause title three lines below is \`**Permutation [bit.permute]**\`. Per the issue, synopsis comments should match the subclause title exactly, so drop the trailing 's'.

Closes #172

## Testing

One-character doc change in the Bikeshed source; re-rendered HTML will reflect it on the next build.