### PR TITLE
docs: fix numeric_limits spelling

### DIFF
--- a/docs/cmath-c23-p3935r0.html
+++ b/docs/cmath-c23-p3935r0.html
@@ -3411,7 +3411,7 @@ Let <code><h- data-h=name>F</h-></code> be the type determined as follows:
 </p><ul>
   <li>Each type in <code><h- data-h=name>Fs</h-></code> is a cv-unqualified arithmetic type.</li>
   <li><code><h- data-h=name>F</h-></code> exists.</li>
-  <li><code><h- data-h=sym_par>(</h-><h- data-h=sym_par>(</h-><h- data-h=name>numeric_limimts</h-><h- data-h=sym_op>&lt;</h-><h- data-h=name>Fs</h-><h- data-h=sym_op>&gt;</h-><h- data-h=sym_op>::</h-><h- data-h=name>radix</h-> <h- data-h=sym_op>==</h-> <h- data-h=name>numeric_limits</h-><h- data-h=sym_op>&lt;</h-><h- data-h=name>F</h-><h- data-h=sym_op>&gt;</h-><h- data-h=sym_op>::</h-><h- data-h=name>radix</h-><h- data-h=sym_par>)</h-> <h- data-h=sym_op>&amp;&amp;</h-> <h- data-h=sym_op>...</h-><h- data-h=sym_par>)</h-></code> is <code><h- data-h=bool>true</h-></code>.</li>
+  <li><code><h- data-h=sym_par>(</h-><h- data-h=sym_par>(</h-><h- data-h=name>numeric_limits</h-><h- data-h=sym_op>&lt;</h-><h- data-h=name>Fs</h-><h- data-h=sym_op>&gt;</h-><h- data-h=sym_op>::</h-><h- data-h=name>radix</h-> <h- data-h=sym_op>==</h-> <h- data-h=name>numeric_limits</h-><h- data-h=sym_op>&lt;</h-><h- data-h=name>F</h-><h- data-h=sym_op>&gt;</h-><h- data-h=sym_op>::</h-><h- data-h=name>radix</h-><h- data-h=sym_par>)</h-> <h- data-h=sym_op>&amp;&amp;</h-> <h- data-h=sym_op>...</h-><h- data-h=sym_par>)</h-></code> is <code><h- data-h=bool>true</h-></code>.</li>
   <li><code><h- data-h=name>T</h-></code> is a cv-unqualified floating-point type other than <code><h- data-h=kw_type>long</h-> <h- data-h=kw_type>double</h-></code>.</li>
 </ul>
 <p>[<i>Example</i>: 

--- a/docs/cmath-c23.html
+++ b/docs/cmath-c23.html
@@ -3457,7 +3457,7 @@ Let <code><h- data-h=name>F</h-></code> be the type determined as follows:
 </p><ul>
   <li>Each type in <code><h- data-h=name>Fs</h-></code> is a cv-unqualified arithmetic type.</li>
   <li><code><h- data-h=name>F</h-></code> exists.</li>
-  <li><code><h- data-h=sym_par>(</h-><h- data-h=sym_par>(</h-><h- data-h=name>numeric_limimts</h-><h- data-h=sym_op>&lt;</h-><h- data-h=name>Fs</h-><h- data-h=sym_op>&gt;</h-><h- data-h=sym_op>::</h-><h- data-h=name>radix</h-> <h- data-h=sym_op>==</h-> <h- data-h=name>numeric_limits</h-><h- data-h=sym_op>&lt;</h-><h- data-h=name>F</h-><h- data-h=sym_op>&gt;</h-><h- data-h=sym_op>::</h-><h- data-h=name>radix</h-><h- data-h=sym_par>)</h-> <h- data-h=sym_op>&amp;&amp;</h-> <h- data-h=sym_op>...</h-><h- data-h=sym_par>)</h-></code> is <code><h- data-h=bool>true</h-></code>.</li>
+  <li><code><h- data-h=sym_par>(</h-><h- data-h=sym_par>(</h-><h- data-h=name>numeric_limits</h-><h- data-h=sym_op>&lt;</h-><h- data-h=name>Fs</h-><h- data-h=sym_op>&gt;</h-><h- data-h=sym_op>::</h-><h- data-h=name>radix</h-> <h- data-h=sym_op>==</h-> <h- data-h=name>numeric_limits</h-><h- data-h=sym_op>&lt;</h-><h- data-h=name>F</h-><h- data-h=sym_op>&gt;</h-><h- data-h=sym_op>::</h-><h- data-h=name>radix</h-><h- data-h=sym_par>)</h-> <h- data-h=sym_op>&amp;&amp;</h-> <h- data-h=sym_op>...</h-><h- data-h=sym_par>)</h-></code> is <code><h- data-h=bool>true</h-></code>.</li>
   <li><code><h- data-h=name>T</h-></code> is a cv-unqualified floating-point type other than <code><h- data-h=kw_type>long</h-> <h- data-h=kw_type>double</h-></code>.</li>
 </ul>
 <p>[<i>Example</i>: 

--- a/src/cmath-c23.cow
+++ b/src/cmath-c23.cow
@@ -1870,7 +1870,7 @@ Let \tcode{F} be the type determined as follows:
 \ul{
   \li{Each type in \tcode{Fs} is a cv-unqualified arithmetic type.}
   \li{\tcode{F} exists.}
-  \li{\tcode{((numeric_limimts<Fs>::radix == numeric_limits<F>::radix) && ...)} is \tcode{true}.}
+  \li{\tcode{((numeric_limits<Fs>::radix == numeric_limits<F>::radix) && ...)} is \tcode{true}.}
   \li{\tcode{T} is a cv-unqualified floating-point type other than \tcode{long double}.}
 }
 \example{


### PR DESCRIPTION
Fixes #210

Changes:
- `numeric_limimts` -> `numeric_limits` in `src/cmath-c23.cow` (1 occurrence(s))
- `numeric_limimts` -> `numeric_limits` in `docs/cmath-c23-p3935r0.html` (1 occurrence(s))
- `numeric_limimts` -> `numeric_limits` in `docs/cmath-c23.html` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Verified no duplicate open PR was found for the referenced issue number(s) before opening this PR.
