### PR TITLE
P4444: Alleviate concerns in trifurcation 

### DIFF
--- a/docs/big-int.html
+++ b/docs/big-int.html
@@ -3242,6 +3242,8 @@ especially when the goal is to have a high-performance implementation.
 a libstdc++ <code><h- data-h=name>std</h-><h- data-h=sym_op>::</h-><h- data-h=name>big_int</h-></code>,
 a libc++ <code><h- data-h=name>std</h-><h- data-h=sym_op>::</h-><h- data-h=name>big_int</h-></code>, and
 an MSVC <code><h- data-h=name>std</h-><h- data-h=sym_op>::</h-><h- data-h=name>big_int</h-></code>.
+However, this work is already trifurcated among the vendors' existing big integer types (see above),
+so standardization does not create additional duplicated effort so much as relocate this exisiting work for the benefit of users.
 </p>
 <h2 id=implementation-experience><a class=para href=#implementation-experience></a>6. Implementation experience</h2>
 

--- a/src/big-int.cow
+++ b/src/big-int.cow
@@ -1594,6 +1594,8 @@ The biggest remaining concern is that standardization trifurcates the implementa
 a libstdc++ \tcode{std::big_int},
 a libc++ \tcode{std::big_int}, and
 an MSVC \tcode{std::big_int}.
+However, this work is already trifurcated among the vendors' existing big integer types (see above),
+so standardization does not create additional duplicated effort so much as relocate this exisiting work for the benefit of users.
 
 \h2{Implementation experience}
 


### PR DESCRIPTION
As currently written the paragraph ends with:

```
The biggest remaining concern is that standardization trifurcates the implementations into
a libstdc++ \tcode{std::big_int},
a libc++ \tcode{std::big_int}, and
an MSVC \tcode{std::big_int}.
```

which feels to me like an incomplete thought, or leaves this concern dangling for the reader to latch onto. My edit is a single sentence to try and eliminate this dangling concern